### PR TITLE
Fix startup issues on Py3.5/Dj1.10

### DIFF
--- a/django_jinja_knockout/middleware.py
+++ b/django_jinja_knockout/middleware.py
@@ -7,6 +7,10 @@ from django.utils import timezone
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.contrib.auth import get_backends, logout as auth_logout
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    from .utils.deprecation import MiddlewareMixin
 
 from .utils import sdv
 from .utils.modules import get_fqn
@@ -50,12 +54,13 @@ class ImmediateJsonResponse(ImmediateHttpResponse):
         )
 
 
-class ContextMiddleware(object):
+class ContextMiddleware(MiddlewareMixin):
 
     _threadmap = {}
     _mock_request = None
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.request = None
         self.view_func = None
         self.view_args = None

--- a/django_jinja_knockout/utils/deprecation.py
+++ b/django_jinja_knockout/utils/deprecation.py
@@ -1,0 +1,14 @@
+class MiddlewareMixin(object):
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+        super(MiddlewareMixin, self).__init__()
+
+    def __call__(self, request):
+        response = None
+        if hasattr(self, 'process_request'):
+            response = self.process_request(request)
+        if not response:
+            response = self.get_response(request)
+        if hasattr(self, 'process_response'):
+            response = self.process_response(request, response)
+        return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ django>=1.8.0
 Jinja2>=2.8
 django-jinja>=1.4.1
 bleach>=1.4.2
+html5lib<0.99999999
 lxml>=3.4.4
 ensure>=0.3.2
 sqlparse>=0.2.1


### PR DESCRIPTION
- Django's new middleware API calls middlewares with an extra argument,
  as per [1]. Use the same approach to provide forward compatibility.
- Html5lib per version 0.9999999 has reworked the sanitizer API. Bleach
  will follow, but until then, we must use a lower version [2]

For the first issue the traceback was this on uwsgi startup:

  File ".../site-packages/django/core/wsgi.py", line 14, in get_wsgi_application
    return WSGIHandler()
  File ".../site-packages/django/core/handlers/wsgi.py", line 153, in __init__
    self.load_middleware()
  File ".../site-packages/django/core/handlers/base.py", line 82, in load_middleware
    mw_instance = middleware(handler)
TypeError: __init__() takes 1 positional argument but 2 were given

[1] https://github.com/django/django/commit/9baf692
[2] https://github.com/mozilla/bleach/commit/567eebb5