### PR TITLE
Reduce the possibility of circular import in forms.base and templatetags/fields.py

### DIFF
--- a/django_jinja_knockout/forms/base.py
+++ b/django_jinja_knockout/forms/base.py
@@ -9,9 +9,9 @@ from django import forms
 from django.forms.models import BaseInlineFormSet, ModelFormMetaclass, inlineformset_factory
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 
-from ..apps import DjkAppConfig
+from .. import apps
 from ..utils import sdv
-from ..widgets import DisplayText
+from .. import widgets
 from ..viewmodels import to_json
 
 from . import renderers
@@ -32,7 +32,7 @@ class RendererModelForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Automatically make current http request available as .request attribute of form instance.
-        context_middleware = DjkAppConfig.get_context_middleware()
+        context_middleware = apps.DjkAppConfig.get_context_middleware()
         self.request = context_middleware.get_request()
         if hasattr(self.Meta, 'field_templates'):
             for field_name in self.Meta.field_templates:
@@ -55,7 +55,7 @@ class BootstrapModelForm(RendererModelForm):
 
 # Set all default (implicit) widgets to DisplayText.
 def display_model_formfield_callback(db_field, **kwargs):
-    defaults = {'widget': DisplayText}
+    defaults = {'widget': widgets.DisplayText}
     defaults.update(kwargs)
     return db_field.formfield(**defaults)
 

--- a/django_jinja_knockout/templatetags/fields.py
+++ b/django_jinja_knockout/templatetags/fields.py
@@ -1,5 +1,5 @@
 from django import forms
-from ..widgets import DisplayText, PrefillWidget
+from .. import widgets #DisplayText, PrefillWidget
 
 
 def is_visible_field(model_field):
@@ -19,11 +19,11 @@ def is_select_multiple_field(model_field):
 
 
 def is_displaytext_field(model_field):
-    return isinstance(model_field.widget, DisplayText)
+    return isinstance(model_field.widget, widgets.DisplayText)
 
 
 def is_prefill_field(model_field):
-    return isinstance(model_field.widget, PrefillWidget)
+    return isinstance(model_field.widget, widgets.PrefillWidget)
 
 
 def filter_get_display_layout(field):

--- a/django_jinja_knockout/templatetags/fields.py
+++ b/django_jinja_knockout/templatetags/fields.py
@@ -1,5 +1,5 @@
 from django import forms
-from .. import widgets #DisplayText, PrefillWidget
+from .. import widgets
 
 
 def is_visible_field(model_field):

--- a/django_jinja_knockout/widgets.py
+++ b/django_jinja_knockout/widgets.py
@@ -9,7 +9,7 @@ from django.forms.utils import flatatt
 from django.forms.widgets import (CheckboxInput, Widget, ChoiceWidget, Textarea, MultiWidget)
 from django.db.models.query import RawQuerySet, QuerySet
 
-from .apps import DjkAppConfig
+from . import apps
 from .models import model_fields_verbose_names
 from .query import ListQuerySet
 from .tpl import (
@@ -28,7 +28,7 @@ class RendererWidget(Widget):
     template_name = None
 
     def ioc_renderer(self, context):
-        ContextMiddleware = DjkAppConfig.get_context_middleware()
+        ContextMiddleware = apps.DjkAppConfig.get_context_middleware()
         request = ContextMiddleware.get_request()
         return self.renderer_class(request, template=self.template_name, context=context)
 
@@ -281,7 +281,7 @@ class BaseGridWidget(ChoiceWidget):
         widget_ctx['value'] = value
 
         # Autodetect foreign key widgets fkGridOptions.
-        ContextMiddleware = DjkAppConfig.get_context_middleware()
+        ContextMiddleware = apps.DjkAppConfig.get_context_middleware()
         self.request = ContextMiddleware.get_request()
         widget_view = resolve_grid(
             request=self.request,


### PR DESCRIPTION
I was having circular import problems in my project with django-jinja-knockout, this commit solves it in a similar way i have seen on the commit history.