### PR TITLE
Reduce the possibility of circular imports on django startup

### DIFF
--- a/django_jinja_knockout/apps.py
+++ b/django_jinja_knockout/apps.py
@@ -2,7 +2,6 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.utils.module_loading import import_string
 
-from . import middleware
 
 
 class DjkAppConfig(AppConfig):
@@ -11,7 +10,8 @@ class DjkAppConfig(AppConfig):
 
     @classmethod
     def get_context_middleware(cls):
+        from .middleware import ContextMiddleware # Inside method to prevent circular import
         if cls.djk_middleware is None:
             cls.djk_middleware = import_string(settings.DJK_MIDDLEWARE) if hasattr(settings, 'DJK_MIDDLEWARE') \
-                else middleware.ContextMiddleware
+                else ContextMiddleware
         return cls.djk_middleware


### PR DESCRIPTION
Reduce the posibility of circular imports on django startup using django-jinja-knockout, simpler than the pull request #11 