### PR TITLE
Check if removecomponent function is defined before calling it

### DIFF
--- a/django_jinja_knockout/static/djk/js/app.js
+++ b/django_jinja_knockout/static/djk/js/app.js
@@ -2978,7 +2978,9 @@ void function(Components) {
             $selector.unbind(desc.event, desc.handler);
         }
         if (component !== undefined) {
-            component.removeComponent($selector);
+            if (typeof component.removeComponent !== 'undefined') {
+                component.removeComponent($selector);
+            }
             this.list[componentIdx] = null;
         }
         return desc;


### PR DESCRIPTION
When adding bs_tabs inside a form that is displayed inside a modal (for example an edit form from a grid element), when closing the modal an error shows that component.removeComponent is undefined. Adding this check avoids this error, but I don't know if this is the correct solution or the bootstrap tabs need a definition of this function.